### PR TITLE
Add initial namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Creates a new Virtual Machine inside a privileged docker container.
 | --flavor value    | VM specs descriptor                                             | Yes      |
 | --key value       | SSH key to be included in a cloud image                         | No       |
 | --name value      | VM name                                                         | No       |
+| --namespace value | VM namespace (this will normally be the user's username)        | No       |
 | --cpumodel value  | Model of the virtual cpu. See: ``qemu-system-x86_64 -cpu help`` | No       |
 | --sockets value   | Number of sockets. (default: 1)                                 | No       |
 | --cpus value      | Number of cpus (default: 1)                                     | No       |
@@ -72,6 +73,11 @@ Removes a the whole privileged docker container and its virtual machine data.
 list
 ----
 Lists all virtual machines that were created with the ``govm`` tool. It also shows the VNC access url and name.
+
+| Flag              | Description                       | Required |
+|-------------------|-----------------------------------|----------|
+| --all             | Show VMs from all namespaces      | No       |
+| --namespace value | Show VMs from the given namespace | No       |
 
 *Output example:*
 ```

--- a/cli/create.go
+++ b/cli/create.go
@@ -7,13 +7,17 @@ import (
 	"strings"
 
 	"github.com/codegangsta/cli"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/govm-project/govm/types"
+	"github.com/govm-project/govm/utils"
 	"github.com/govm-project/govm/vm"
+	log "github.com/sirupsen/logrus"
 )
 
 func create() cli.Command {
+	defaultNamespace, err := utils.DefaultNamespace()
+	if err != nil {
+		log.Fatalf("get default namespace: %v", err)
+	}
 	command := cli.Command{
 		Name:      "create",
 		Aliases:   []string{"c"},
@@ -51,6 +55,11 @@ func create() cli.Command {
 				Name:  "name",
 				Value: "",
 				Usage: "vm name",
+			},
+			cli.StringFlag{
+				Name:  "namespace",
+				Value: defaultNamespace,
+				Usage: "vm namespace",
 			},
 			cli.StringFlag{
 				Name:  "cpumodel",
@@ -148,6 +157,7 @@ func create() cli.Command {
 			}
 			newVM := vm.CreateVM(
 				c.String("name"),
+				c.String("namespace"),
 				parentImage,
 				workDir,
 				c.String("key"),

--- a/cli/list.go
+++ b/cli/list.go
@@ -10,18 +10,29 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+	"github.com/govm-project/govm/utils"
 	log "github.com/sirupsen/logrus"
 )
 
 func list() cli.Command {
+	defaultNamespace, err := utils.DefaultNamespace()
+	if err != nil {
+		log.Fatalf("get default namespace: %v", err)
+	}
 	command := cli.Command{
 		Name:    "list",
 		Aliases: []string{"ls"},
 		Usage:   "List vms",
 		Flags: []cli.Flag{
 			cli.BoolFlag{
-				Name:  "all",
-				Usage: "List all images",
+				Name: "all",
+				// Usage: "List all images",
+				Usage: "list VMs from all namespaces",
+			},
+			cli.StringFlag{
+				Name:  "namespace",
+				Value: defaultNamespace,
+				Usage: "list VMs from this namespace",
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -31,8 +42,14 @@ func list() cli.Command {
 			if err != nil {
 				panic(err)
 			}
+			namespace := c.String("namespace")
+
 			listArgs := filters.NewArgs()
 			listArgs.Add("ancestor", VMLauncherContainerImage)
+			if !c.Bool("all") {
+				listArgs.Add("label", "namespace="+namespace)
+			}
+
 			containers, err := cli.ContainerList(context.Background(),
 				types.ContainerListOptions{
 					Quiet:   false,
@@ -47,17 +64,32 @@ func list() cli.Command {
 			if err != nil {
 				panic(err)
 			}
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-			fmt.Fprintln(w, "ID\t IP\t VNC_URL\t NAME")
-			for _, container := range containers {
-				for _, net := range container.NetworkSettings.Networks {
-					containerIP = net.IPAddress
-					break
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			if c.Bool("all") {
+				fmt.Fprintln(w, "ID\tIP\tVNC URL\tNAME\tNAMESPACE")
+				for _, container := range containers {
+					for _, net := range container.NetworkSettings.Networks {
+						containerIP = net.IPAddress
+						break
+					}
+					fmt.Fprintf(w, "%s\t%s\thttp://localhost:%s\t%s\t%s\n",
+						container.ID[:10], containerIP,
+						container.Labels["websockifyPort"],
+						container.Labels["vmName"],
+						container.Labels["namespace"])
 				}
-				fmt.Fprintln(w, container.ID[:10]+
-					"\t "+containerIP+
-					"\t http://localhost:"+container.Labels["websockifyPort"]+
-					"\t "+container.Names[0][1:])
+			} else {
+				fmt.Fprintln(w, "ID\tIP\tVNC URL\tNAME")
+				for _, container := range containers {
+					for _, net := range container.NetworkSettings.Networks {
+						containerIP = net.IPAddress
+						break
+					}
+					fmt.Fprintln(w, container.ID[:10]+
+						"\t "+containerIP+
+						"\t http://localhost:"+container.Labels["websockifyPort"]+
+						"\t "+container.Labels["vmName"])
+				}
 			}
 
 			err = w.Flush()

--- a/cli/remove.go
+++ b/cli/remove.go
@@ -16,7 +16,7 @@ import (
 )
 
 func remove() cli.Command {
-	defeaultNamespace, err := utils.DefaultNamespace()
+	defaultNamespace, err := utils.DefaultNamespace()
 	if err != nil {
 		log.Fatalf("get default namespace: %v", err)
 	}

--- a/cli/util.go
+++ b/cli/util.go
@@ -26,13 +26,13 @@ func NewVMTemplate(c *vmLauncher.ComposeTemplate) vmLauncher.ComposeTemplate {
 		panic(err)
 	}
 
-	globalNamespace := c.Namespace
-	if globalNamespace == "" {
-		defaultNamespace, err := utils.DefaultNamespace()
+	defaultNamespace := c.Namespace
+	if defaultNamespace == "" {
+		var err error
+		defaultNamespace, err = utils.DefaultNamespace()
 		if err != nil {
 			log.Fatalf("get default namespace: %v", err)
 		}
-		globalNamespace = defaultNamespace
 	}
 
 	for _, vm := range c.VMs {
@@ -50,7 +50,7 @@ func NewVMTemplate(c *vmLauncher.ComposeTemplate) vmLauncher.ComposeTemplate {
 		// Check if a namespace was given.
 		namespace := vm.Namespace
 		if namespace == "" {
-			namespace = globalNamespace
+			namespace = defaultNamespace
 		}
 
 		newVMTemplate.VMs = append(newVMTemplate.VMs,

--- a/cli/util.go
+++ b/cli/util.go
@@ -11,9 +11,8 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/golang/glog"
-	log "github.com/sirupsen/logrus"
-
 	vmLauncher "github.com/govm-project/govm/vm"
+	log "github.com/sirupsen/logrus"
 )
 
 //NewVMTemplate creates a new VMTemplate object
@@ -40,6 +39,7 @@ func NewVMTemplate(c *vmLauncher.ComposeTemplate) vmLauncher.ComposeTemplate {
 		newVMTemplate.VMs = append(newVMTemplate.VMs,
 			vmLauncher.CreateVM(
 				vm.Name,
+				vm.Namespace,
 				vm.ParentImage,
 				vm.Workdir,
 				vm.SSHKey,

--- a/utils/names.go
+++ b/utils/names.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"fmt"
+	"os/user"
+	"strings"
+
+	"github.com/docker/docker/pkg/namesgenerator"
+)
+
+const containerPrefix = "govm"
+
+// GenerateContainerName generates a container name based on the namespace
+// and virtual machine name.
+func GenerateContainerName(namespace, vmname string) string {
+	return fmt.Sprintf("%s.%s.%s", containerPrefix, namespace, vmname)
+}
+
+// ParseContainerName takes a container name and returns the VM namespace and
+// name, or an error if the container name is incorrectly formatted.
+func ParseContainerName(contname string) (ns, vmname string, err error) {
+	parts := strings.Split(contname, ".")
+	if len(parts) != 3 {
+		return "", "", fmt.Errorf("%q has an invalid container name", contname)
+	}
+	if parts[0] != containerPrefix {
+		return parts[1], parts[2], fmt.Errorf(
+			"%q has an invalid prefix (should be %q)", contname, containerPrefix)
+	}
+	return parts[1], parts[2], nil
+}
+
+// DefaultNamespace returns the default namespace for a user, which generally is
+// the user's username.
+func DefaultNamespace() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("get current user: %v", err)
+	}
+	return u.Username, nil
+}
+
+// RandomName returns a randomly generated name. This just wraps docker's
+// namesgenerator.GetRandomName() to avoid extra imports.
+func RandomName() string {
+	return namesgenerator.GetRandomName(0)
+}

--- a/vm/types.go
+++ b/vm/types.go
@@ -6,6 +6,7 @@ import (
 
 //ComposeTemplate defines a VMs orchestration template
 type ComposeTemplate struct {
-	VMs      []VM             `yaml:"vms"`
-	Networks []docker.Network `yaml:"networks"`
+	VMs       []VM             `yaml:"vms"`
+	Networks  []docker.Network `yaml:"networks"`
+	Namespace string           `yaml:"namespace"`
 }


### PR DESCRIPTION
On machines with multiple users, each user can see other users' virtual
machines. This patch adds initial support for namespaces, which helps
divide VMs into individual users' namespaces. Also, VM containers will
now be named `govm.<namespace>.<VMName>` to more easily identify them as
govm VMs from `docker ps`. Additionally, `govm` commands now accept a
`--namespace` flag to change namespaces, and the `govm list` command
also accepts a `--all` flag to list VMs from all namespaces. Note that
there is nothing stopping any user from creating or deleting VMs in
another user's namespace.