### PR TITLE
Update search pattern for resolv.conf

### DIFF
--- a/startvm
+++ b/startvm
@@ -392,8 +392,8 @@ if [[ "$ENABLE_DHCP" == 1 ]]; then
     iptables -A POSTROUTING -t mangle -p udp --dport bootpc -j CHECKSUM --checksum-fill
 
     # Build DNS options from container /etc/resolv.conf
-    nameservers=($(grep nameserver /etc/resolv.conf | sed 's/nameserver //'))
-    searchdomains=$(grep search /etc/resolv.conf | sed 's/search //' | sed 's/ /,/g')
+    nameservers=($(grep ^nameserver /etc/resolv.conf | sed 's/nameserver //'))
+    searchdomains=$(grep ^search /etc/resolv.conf | sed 's/search //' | sed 's/ /,/g')
     domainname=$(echo $searchdomains | awk -F"," '{print $1}')
 
     for nameserver in "${nameservers[@]}"; do


### PR DESCRIPTION
Add strict case for pattern searching on resolv.conf file.
It make sure that `nameserver` and `search` keyword are
the start of the string when looking for name servers and
search domains on resolv.conf.

Signed-off-by: Obed N Munoz <obed.n.munoz@gmail.com>