### PR TITLE
Make root disk size configurable

### DIFF
--- a/engines/docker/engine.go
+++ b/engines/docker/engine.go
@@ -46,6 +46,7 @@ func (e Engine) Create(spec vm.Instance) (id string, err error) {
 			(spec.Size.Sockets * spec.Size.Cores * spec.Size.Threads),
 			spec.Size.RAM,
 		),
+		fmt.Sprintf("COW_SIZE=%dG", spec.Size.DISK),
 	}
 	env = append(env, spec.ContainerEnvVars...)
 

--- a/pkg/cli/create.go
+++ b/pkg/cli/create.go
@@ -78,7 +78,12 @@ var createCommand = cli.Command{
 		&cli.IntFlag{
 			Name:  "ram",
 			Value: 1024,
-			Usage: "Allocated RAM",
+			Usage: "Allocated RAM in MB",
+		},
+		&cli.IntFlag{
+			Name:  "disk",
+			Value: 50,
+			Usage: "Root disk size in GB",
 		},
 		&cli.BoolFlag{
 			Name:  "debug",
@@ -115,6 +120,7 @@ var createCommand = cli.Command{
 				ctx.Int("cores"),
 				ctx.Int("threads"),
 				ctx.Int("ram"),
+				ctx.Int("disk"),
 			)
 		}
 

--- a/vm/const.go
+++ b/vm/const.go
@@ -22,3 +22,6 @@ const (
 	MedatataFile  = "meta_data.json"
 	UserDataMount = "%s:/cloud-init/openstack/latest/user_data"
 )
+
+// Default size of qcow2 root disk in GB.
+const DiskDefaultSizeGB = 50

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -22,6 +22,7 @@ type Size struct {
 	Cores    int    `yaml:"cores"`
 	Threads  int    `yaml:"threads"`
 	RAM      int    `yaml:"ram"`
+	DISK     int    `yaml:"disk"`
 }
 
 //ConfigDriveMetaData stands for cloud images config drive
@@ -202,7 +203,7 @@ func (ins *Instance) Check() (err error) {
 }
 
 //NewSize creates a new VMSize specification
-func NewSize(model string, sockets, cpus, cores, threads, ram int) Size {
+func NewSize(model string, sockets, cpus, cores, threads, ram, disk int) Size {
 	var vmSize Size
 
 	if model != "" {
@@ -243,6 +244,12 @@ func NewSize(model string, sockets, cpus, cores, threads, ram int) Size {
 		vmSize.RAM = 4096
 	}
 
+	if disk != 0 {
+		vmSize.DISK = disk
+	} else {
+		vmSize.DISK = DiskDefaultSizeGB
+	}
+
 	return vmSize
 }
 
@@ -258,17 +265,17 @@ func GetSizeFromFlavor(flavor string) (size Size) {
 
 	switch flavor {
 	case "micro":
-		size = NewSize(cpuModel, 1, 1, 1, 1, 512)
+		size = NewSize(cpuModel, 1, 1, 1, 1, 512, DiskDefaultSizeGB)
 	case "tiny":
-		size = NewSize(cpuModel, 1, 1, 1, 1, 1024)
+		size = NewSize(cpuModel, 1, 1, 1, 1, 1024, 2*DiskDefaultSizeGB)
 	case "small":
-		size = NewSize(cpuModel, 1, 1, 2, 1, 2048)
+		size = NewSize(cpuModel, 1, 1, 2, 1, 2048, 4*DiskDefaultSizeGB)
 	case "medium":
-		size = NewSize(cpuModel, 2, 2, 2, 2, 4096)
+		size = NewSize(cpuModel, 2, 2, 2, 2, 4096, 8*DiskDefaultSizeGB)
 	case "large":
-		size = NewSize(cpuModel, 1, 4, 4, 4, 8192)
+		size = NewSize(cpuModel, 1, 4, 4, 4, 8192, 16*DiskDefaultSizeGB)
 	default:
-		size = NewSize(cpuModel, 2, 2, 2, 2, 4096)
+		size = NewSize(cpuModel, 2, 2, 2, 2, 4096, DiskDefaultSizeGB)
 	}
 	return
 }


### PR DESCRIPTION
In the Docker container, the root disk is a cow_image.qcow2 image with
a size that previously was hard-coded to 50GB in the container start
script. Now that value can be configured (--disk parameter, "disk"
entry in the "size" struct of a VM instance when using a compose file).

When using a compose file that determines the size based on the
"flavor", the disk size defaults are increasing exponentially: 50GB
for "micro", 100GB for "tiny", etc.

Because the image file is a sparse file, this usually doesn't increase
actual disk usage unless the VM really writes much data.