### PR TITLE
Add `stop` sub-command

### DIFF
--- a/engines/docker/docker.go
+++ b/engines/docker/docker.go
@@ -94,6 +94,20 @@ func (d *Docker) Start(id, name string) error {
 	return d.ContainerStart(d.ctx, id, types.ContainerStartOptions{})
 }
 
+// Stop stops a previously started container.
+func (d *Docker) Stop(id, name string) error {
+	if id == "" {
+		container, err := d.Search(name)
+		if err != nil {
+			return err
+		}
+
+		id = container.ID
+	}
+
+	return d.ContainerStop(d.ctx, id, nil)
+}
+
 // Search searches a container from the running docker containers
 func (d *Docker) Search(name string) (types.Container, error) {
 	containers, err := d.ContainerList(d.ctx, types.ContainerListOptions{})

--- a/engines/docker/engine.go
+++ b/engines/docker/engine.go
@@ -153,8 +153,18 @@ func (e Engine) Start(namespace, id string) error {
 }
 
 // Stop stops a Docker container-based VM instance
-func (e Engine) Stop(id string) error {
-	return nil
+func (e Engine) Stop(namespace, id string) error {
+	container, err := e.docker.Inspect(id)
+	if err != nil {
+		fullName := internal.GenerateContainerName(namespace, id)
+		container, err = e.docker.Inspect(fullName)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return e.docker.Stop(container.ID,"")
 }
 
 // List lists  all the Docker container-based VM instances

--- a/engines/engine.go
+++ b/engines/engine.go
@@ -9,6 +9,7 @@ import (
 type VMEngine interface {
 	CreateVM(spec vm.Instance) (string, error)
 	StartVM(namespace, id string) error
+	StopVM(namespace, id string) error
 	DeleteVM(namespace, id string) error
 	SSHVM(namespace, id, user, key string, term *termutil.Terminal) error
 	ListVM(namespace string, all bool) ([]vm.Instance, error)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -36,6 +36,7 @@ func New() (*cli.App, error) {
 			&startCommand,
 			&composeCommand,
 			&sshCommand,
+			&stopCommand,
 		},
 	}, nil
 }

--- a/pkg/cli/stop.go
+++ b/pkg/cli/stop.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/govm-project/govm/engines/docker"
+	log "github.com/sirupsen/logrus"
+	cli "gopkg.in/urfave/cli.v2"
+)
+
+// nolint: gochecknoglobals
+var stopCommand = cli.Command{
+	Name:    "stop",
+	Aliases: []string{"down", "d"},
+	Usage:   "Stop a GoVM Instance",
+	Flags:   []cli.Flag{},
+	Action: func(c *cli.Context) error {
+		if c.NArg() <= 0 {
+			err := errors.New("missing GoVM Instance name")
+			fmt.Println(err)
+			fmt.Printf("USAGE:\n govm stop [command options] [name]\n")
+			os.Exit(1)
+		}
+
+		namespace :=c.String("namespace")
+		name := c.Args().First()
+
+		engine := docker.Engine{}
+		engine.Init()
+		err := engine.Stop(namespace,name)
+		if err != nil {
+			log.Fatalf("Error when stopping the GoVM Instance %v: %v", name, err)
+		}
+
+		log.Printf("GoVM Instance %v has been successfully stopped", name)
+
+		return nil
+	},
+}


### PR DESCRIPTION
This change adds support for `stop` sub-command.
It will stop a GoVM instance either by instance or ID.