### PR TITLE
Add support for `stop` subcommand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 script:
-  - golangci-lint run --enable-all
+  - golangci-lint run --enable-all --disable gomnd
   - go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
 after_success:

--- a/engines/docker/docker.go
+++ b/engines/docker/docker.go
@@ -94,6 +94,20 @@ func (d *Docker) Start(id, name string) error {
 	return d.ContainerStart(d.ctx, id, types.ContainerStartOptions{})
 }
 
+// Stop stops a previously started container.
+func (d *Docker) Stop(id, name string) error {
+	if id == "" {
+		container, err := d.Search(name)
+		if err != nil {
+			return err
+		}
+
+		id = container.ID
+	}
+
+	return d.ContainerStop(d.ctx, id, nil)
+}
+
 // Search searches a container from the running docker containers
 func (d *Docker) Search(name string) (types.Container, error) {
 	containers, err := d.ContainerList(d.ctx, types.ContainerListOptions{})

--- a/engines/docker/engine.go
+++ b/engines/docker/engine.go
@@ -164,7 +164,7 @@ func (e Engine) Stop(namespace, id string) error {
 		}
 	}
 
-	return e.docker.Stop(container.ID,"")
+	return e.docker.Stop(container.ID, "")
 }
 
 // List lists  all the Docker container-based VM instances

--- a/engines/docker/engine.go
+++ b/engines/docker/engine.go
@@ -153,8 +153,18 @@ func (e Engine) Start(namespace, id string) error {
 }
 
 // Stop stops a Docker container-based VM instance
-func (e Engine) Stop(id string) error {
-	return nil
+func (e Engine) Stop(namespace, id string) error {
+	container, err := e.docker.Inspect(id)
+	if err != nil {
+		fullName := internal.GenerateContainerName(namespace, id)
+		container, err = e.docker.Inspect(fullName)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return e.docker.Stop(container.ID,"")
 }
 
 // List lists  all the Docker container-based VM instances

--- a/engines/docker/ssh.go
+++ b/engines/docker/ssh.go
@@ -96,6 +96,7 @@ func (e *Engine) SSHVM(namespace, id, user, key string, term *termutil.Terminal)
 	go func() {
 		sigch := make(chan os.Signal, 1)
 		signal.Notify(sigch, syscall.SIGWINCH)
+
 		defer signal.Stop(sigch)
 		defer close(sigch)
 	outer:

--- a/engines/engine.go
+++ b/engines/engine.go
@@ -9,6 +9,7 @@ import (
 type VMEngine interface {
 	CreateVM(spec vm.Instance) (string, error)
 	StartVM(namespace, id string) error
+	StopVM(namespace, id string) error
 	DeleteVM(namespace, id string) error
 	SSHVM(namespace, id, user, key string, term *termutil.Terminal) error
 	ListVM(namespace string, all bool) ([]vm.Instance, error)

--- a/go.mod
+++ b/go.mod
@@ -1,40 +1,43 @@
 module github.com/govm-project/govm
 
 require (
-	github.com/Microsoft/go-winio v0.4.12 // indirect
-	github.com/docker/distribution v2.6.2+incompatible // indirect
+	github.com/Microsoft/go-winio v0.4.14 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/go-units v0.3.3 // indirect
-	github.com/gogo/protobuf v1.3.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
+	github.com/fatih/color v1.9.0 // indirect
+	github.com/go-critic/go-critic v0.4.1 // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golangci/gocyclo v0.0.0-20180528144436-0a533e8fa43d // indirect
-	github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a // indirect
-	github.com/golangci/golangci-lint v1.19.1 // indirect
+	github.com/golangci/golangci-lint v1.22.2 // indirect
 	github.com/golangci/revgrep v0.0.0-20180812185044-276a5c0a1039 // indirect
-	github.com/google/go-cmp v0.2.0
+	github.com/google/go-cmp v0.4.0
 	github.com/gostaticanalysis/analysisutil v0.0.3 // indirect
 	github.com/intel/tfortools v0.2.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-	github.com/magiconair/properties v1.8.1 // indirect
-	github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb // indirect
-	github.com/mattn/go-colorable v0.1.4 // indirect
-	github.com/mattn/go-isatty v0.0.9 // indirect
-	github.com/pelletier/go-toml v1.4.0 // indirect
-	github.com/securego/gosec v0.0.0-20191001071045-ad375d3b8fe3 // indirect
+	github.com/novalagung/gorep v0.0.0-20160927021757-96a7001c9934 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/pelletier/go-toml v1.6.0 // indirect
+	github.com/pkg/errors v0.9.0 // indirect
+	github.com/securego/gosec v0.0.0-20200106085552-9cb83e10afad // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/afero v1.2.2 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/stevvooe/resumable v0.0.0-20180830230917-22b14a53ba50 // indirect
-	github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e // indirect
-	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392
-	golang.org/x/net v0.0.0-20190923162816-aa69164e4478
-	golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24
-	golang.org/x/tools v0.0.0-20191001123449-8b695b21ef34 // indirect
+	github.com/urfave/cli/v2 v2.1.1
+	golang.org/x/crypto v0.0.0-20200109152110-61a87790db17
+	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
+	golang.org/x/sys v0.0.0-20200113162924-86b910548bc1
+	golang.org/x/tools v0.0.0-20200113211014-78c17663447c // indirect
+	gopkg.in/ini.v1 v1.51.1 // indirect
 	gopkg.in/urfave/cli.v2 v2.0.0-20180128182452-d3ae77c26ac8
-	gopkg.in/yaml.v2 v2.2.3
+	gopkg.in/yaml.v2 v2.2.7
 	gotest.tools v2.2.0+incompatible
-	mvdan.cc/unparam v0.0.0-20190917161559-b83a221c10a2 // indirect
+	mvdan.cc/unparam v0.0.0-20191111180625-960b1ec0f2c2 // indirect
 	sourcegraph.com/sqs/pbtypes v1.0.0 // indirect
 )
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/govm-project/govm/pkg/cli"
-	clilib "gopkg.in/urfave/cli.v2"
+	clilib "github.com/urfave/cli/v2"
 )
 
 var version = "undefined"

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -36,6 +36,7 @@ func New() (*cli.App, error) {
 			&startCommand,
 			&composeCommand,
 			&sshCommand,
+			&stopCommand,
 		},
 	}, nil
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"github.com/govm-project/govm/pkg/homedir"
 	"github.com/govm-project/govm/pkg/nameutil"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 // New creates a new command line GoVM application

--- a/pkg/cli/compose.go
+++ b/pkg/cli/compose.go
@@ -9,7 +9,7 @@ import (
 	"github.com/govm-project/govm/internal"
 	"github.com/govm-project/govm/vm"
 	log "github.com/sirupsen/logrus"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 	yaml "gopkg.in/yaml.v2"
 )
 

--- a/pkg/cli/create.go
+++ b/pkg/cli/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/govm-project/govm/vm"
 
 	log "github.com/sirupsen/logrus"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 // nolint: gochecknoglobals

--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/govm-project/govm/engines/docker"
 
 	"github.com/intel/tfortools"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 // nolint: gochecknoglobals

--- a/pkg/cli/remove.go
+++ b/pkg/cli/remove.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/govm-project/govm/engines/docker"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/cli/ssh.go
+++ b/pkg/cli/ssh.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/govm-project/govm/engines/docker"
 	"github.com/govm-project/govm/pkg/termutil"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 // nolint: gochecknoglobals

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/govm-project/govm/engines/docker"
 	log "github.com/sirupsen/logrus"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 // nolint: gochecknoglobals

--- a/pkg/cli/stop.go
+++ b/pkg/cli/stop.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/govm-project/govm/engines/docker"
+	log "github.com/sirupsen/logrus"
+	cli "gopkg.in/urfave/cli.v2"
+)
+
+// nolint: gochecknoglobals
+var stopCommand = cli.Command{
+	Name:    "stop",
+	Aliases: []string{"down", "d"},
+	Usage:   "Stop a GoVM Instance",
+	Flags:   []cli.Flag{},
+	Action: func(c *cli.Context) error {
+		if c.NArg() <= 0 {
+			err := errors.New("missing GoVM Instance name")
+			fmt.Println(err)
+			fmt.Printf("USAGE:\n govm stop [command options] [name]\n")
+			os.Exit(1)
+		}
+
+		namespace :=c.String("namespace")
+		name := c.Args().First()
+
+		engine := docker.Engine{}
+		engine.Init()
+		err := engine.Stop(namespace,name)
+		if err != nil {
+			log.Fatalf("Error when stopping the GoVM Instance %v: %v", name, err)
+		}
+
+		log.Printf("GoVM Instance %v has been successfully stopped", name)
+
+		return nil
+	},
+}

--- a/pkg/cli/stop.go
+++ b/pkg/cli/stop.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/govm-project/govm/engines/docker"
 	log "github.com/sirupsen/logrus"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 // nolint: gochecknoglobals
@@ -24,12 +24,12 @@ var stopCommand = cli.Command{
 			os.Exit(1)
 		}
 
-		namespace :=c.String("namespace")
+		namespace := c.String("namespace")
 		name := c.Args().First()
 
 		engine := docker.Engine{}
 		engine.Init()
-		err := engine.Stop(namespace,name)
+		err := engine.Stop(namespace, name)
 		if err != nil {
 			log.Fatalf("Error when stopping the GoVM Instance %v: %v", name, err)
 		}

--- a/pkg/termutil/term.go
+++ b/pkg/termutil/term.go
@@ -98,8 +98,10 @@ func handleInterrupt(fd uintptr, state *State) {
 			fmt.Println()
 			signal.Stop(sigchan)
 			close(sigchan)
-			_ = restoreTerminal(fd, state)
-			// os.Exit(1)
+
+			if restoreTerminal(fd, state) != nil {
+				os.Exit(1)
+			}
 		}
 	}()
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -70,7 +70,7 @@ type Instance struct {
 }
 
 // Check validates and fixes VMs values
-// nolint: gocyclo, funlen
+// nolint: gocyclo, funlen, gocognit
 func (ins *Instance) Check() (err error) {
 	ins.ParentImage, err = internal.CheckFilePath(ins.ParentImage)
 	if err != nil {


### PR DESCRIPTION
This change adds support for stop sub-command.
It will stop a GoVM instance either by instance or ID.

Closing #41 in order to address missing linter complains and updating dependencies.

@Estefycp authorships remains on this PR.