### PR TITLE
Fix govm image with latest alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ENV container docker
 
 RUN apk update \
 && apk add qemu-system-x86_64 xorriso cdrkit dnsmasq net-tools bridge-utils \
-iproute2 curl bash qemu-img
+iproute2 curl bash qemu-img \
+&& ( apk add qemu-hw-display-qxl || true )
 
 
 COPY startvm /usr/local/bin/startvm

--- a/startvm
+++ b/startvm
@@ -59,17 +59,26 @@ if [ "$SHARED_DIRS" != "" ]; then
     done
 fi
 
-
-: ${KVM_OPTS:="\
+if [ -z "$KVM_OPTS" ]; then
+    KVM_OPTS="\
   -nodefaults \
   -device virtio-balloon-pci,id=balloon0 \
-  -realtime mlock=off \
   -msg timestamp=on \
   -chardev pty,id=charserial0 \
   -device isa-serial,chardev=charserial0,id=serial0 \
   -serial stdio \
   -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \
-  "}
+  "
+
+    if ${LAUNCHER} -version | grep -q -E 'version [0-5]'; then
+        KVM_OPTS="${KVM_OPTS} -realtime mlock=off \
+  "
+    else
+        KVM_OPTS="${KVM_OPTS} -overcommit mem-lock=off \
+  "
+    fi
+fi
+
 # -serial telnet::4555,server,nowait \
 
 : ${KVM_CPU_OPTS:="-m 1024 -smp 4,sockets=4,cores=1,threads=1"}


### PR DESCRIPTION
- Latest alpine installs Qemu 6.0, where "-realtime mlock=off" is
  replaced by "-overcommit mem-lock=off". startvm detects now
  Qemu version, and uses -realtime mlock=off for versions < 6.0.

- apk add qemu-hw-display-qxl on the image if possible. This is
  required with current alpine latest, otherwise Qemu exits with QXL
  error. Failing to include this package is not fatal, as Qemu on older
  alpine images do not require/have it.