### PR TITLE
Fix Alpine Linux pkg conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER obed.n.munoz@gmail.com, erick.cardona.ruiz@gmail.com
 ENV container docker
 
 RUN apk update \
-&& apk add qemu-system-x86_64 xorriso cdrkit dnsmasq net-tools bridge-utils \
+&& apk add qemu-system-x86_64 cdrkit dnsmasq net-tools bridge-utils \
 iproute2 curl bash qemu-img \
 && ( apk add qemu-hw-display-qxl || true )
 


### PR DESCRIPTION
The cdrkit and xorriso are conflicting, so remove the latter.

ERROR: unable to select packages:
  cdrkit-1.1.11-r3:
    conflicts: xorriso-1.5.4-r2[cmd:mkisofs=1.1.11-r3]
    satisfies: world[cdrkit]
  xorriso-1.5.4-r2:
    conflicts: cdrkit-1.1.11-r3[cmd:mkisofs=1.5.4-r2]
    satisfies: world[xorriso]

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>