### PR TITLE
Update deprecated NewEnvClient function call

### DIFF
--- a/engines/docker/docker.go
+++ b/engines/docker/docker.go
@@ -29,7 +29,7 @@ type Docker struct {
 func NewDockerClient() *Docker {
 	SetAPIVersion()
 
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Static check shown that new NewClientWithOps(FromEnv) function should be used instead