### PR TITLE
startvm: use PCI serial device instead of ISA

### DIFF
--- a/startvm
+++ b/startvm
@@ -64,9 +64,8 @@ if [ -z "$KVM_OPTS" ]; then
   -nodefaults \
   -device virtio-balloon-pci,id=balloon0 \
   -msg timestamp=on \
-  -chardev pty,id=charserial0 \
-  -device isa-serial,chardev=charserial0,id=serial0 \
-  -serial stdio \
+  -chardev stdio,id=charserial0 \
+  -device pci-serial,chardev=charserial0,id=serial0 \
   -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \
   "
 


### PR DESCRIPTION
Debian cloud image does not boot with -machine q35 with serial ISA as the kernel cannot open serial port.